### PR TITLE
feat(sms): switch to direct Telstra client

### DIFF
--- a/api/Pipfile
+++ b/api/Pipfile
@@ -26,6 +26,7 @@ SQLAlchemy = "==1.2.6"
 notifications-python-client = "==4.8.1"
 awscli-cwlogs = "<1.5,>=1.4"
 notifications-utils = {path = "file:./../utils#egg=notifications-utils", editable = true}
+Telstra_Messaging = {git = "https://github.com/Telstra/MessagingAPI-SDK-python.git"}
 
 [dev-packages]
 "flake8" = "==3.5.0"

--- a/api/Pipfile.lock
+++ b/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d177f2a0d74271790804a38a8597e3e50e0e408bc1c8160c8ac4fe75230d97f8"
+            "sha256": "5e2c83a8a176fbc1ee26eff522048e45773ead89d6f34973256cfcccc4c02620"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -596,6 +596,9 @@
             ],
             "version": "==3.2.2"
         },
+        "telstra-messaging": {
+            "git": "https://github.com/Telstra/MessagingAPI-SDK-python.git"
+        },
         "urllib3": {
             "hashes": [
                 "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
@@ -635,10 +638,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:1c7960ccfd6a005cd9f7ba884e6316b5e430a3f1a6c37c5f87d8b43f83b54ec9",
-                "sha256:a17a9573a6f475c99b551c0e0a812707ddda1ec9653bed04c13841404ed6f450"
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
             ],
-            "version": "==17.4.0"
+            "version": "==18.1.0"
         },
         "aws-xray-sdk": {
             "hashes": [
@@ -795,17 +798,17 @@
         },
         "docker": {
             "hashes": [
-                "sha256:0d698c3dc4df66c988de5df21a62cdc3450de2fa8523772779e5e23799c41f43",
-                "sha256:f1a512a0dbc518459159d4584572ebc6de2cc8006b2e376eff02cfae7d72aff0"
+                "sha256:43b45b92bed372161a5d4f3c7137e16b30d93845e99a00bc727938e52850694e",
+                "sha256:dc5cc0971a0d36fe94c5ce89bd4adb6c892713500af7b0818708229c3199911a"
             ],
-            "version": "==3.2.1"
+            "version": "==3.3.0"
         },
         "docker-pycreds": {
             "hashes": [
-                "sha256:408ae6ec2b97345e02cbb3a05e0055443a27969e5b61d6773c733b534a40845b",
-                "sha256:c7ab85de2894baff6ee8f15160cbbfa2fd3a04e56f0372c5793d24060687b299"
+                "sha256:764a7ea2f6484bc5de5bf0c060f08b41a1118cf1acb987626b3ff45f3cc40dac",
+                "sha256:e3732a03610a00461a716997670c7010bf1c214a3edc440f7d6a2a3a830ecd9d"
             ],
-            "version": "==0.2.2"
+            "version": "==0.2.3"
         },
         "docopt": {
             "hashes": [
@@ -945,8 +948,6 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:1ec08a51c901dfe44921576ed6e4c1f5b7ecbad403f871397feedb5eb8e4fa14",
-                "sha256:5ff2fbcbab997895ba9ead77e1b38b3ebc2e5c3b8a6194ef918666e4c790a00e",
                 "sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766",
                 "sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9"
             ],

--- a/api/README.md
+++ b/api/README.md
@@ -2,6 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/alphagov/notifications-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/notifications-api?branch=master)
 
 # notifications-api
+
 Notifications api
 Application for the notification api.
 
@@ -48,17 +49,19 @@ SMTP_ADDR=
 SMTP_USER=
 SMTP_PASSWORD=
 
-SMS_ADDR=
-SMS_USER=
-SMS_PASSWORD=
+TELSTRA_MESSAGING_CLIENT_ID=
+TELSTRA_MESSAGING_CLIENT_SECRET=
+IDENTITY_SMS_ADDR=
+IDENTITY_SMS_USER=
+IDENTITY_SMS_PASS=
 "> environment.sh
 ```
 
 NOTES:
 
- * Replace the placeholder key and prefix values as appropriate
- * The SECRET_KEY and DANGEROUS_SALT should match those in the [notifications-admin](https://github.com/alphagov/notifications-admin) app.
- * The  unique prefix for the queue names prevents clashing with others' queues in shared amazon environment and enables filtering by queue name in the SQS interface.
+* Replace the placeholder key and prefix values as appropriate
+* The SECRET_KEY and DANGEROUS_SALT should match those in the [notifications-admin](https://github.com/alphagov/notifications-admin) app.
+* The unique prefix for the queue names prevents clashing with others' queues in shared amazon environment and enables filtering by queue name in the SQS interface.
 
 ### Postgres
 
@@ -70,8 +73,7 @@ To switch redis on you'll need to install it locally. On a OSX we've used brew f
 
         REDIS_ENABLED = True
 
-
-##  To run the application
+## To run the application
 
 First, create a postgres database with the command `createdb notification_api`.
 
@@ -97,8 +99,7 @@ Optionally you can also run this script to run the scheduled tasks:
 scripts/run_celery_beat.sh
 ```
 
-
-##  To test the application
+## To test the application
 
 First, ensure that `make setup` has been run, as it updates the test database
 
@@ -111,8 +112,6 @@ make test
 That will run flake8 for code analysis and our unit test suite. If you wish to run our functional tests, instructions can be found in the
 [notifications-functional-tests](https://github.com/alphagov/notifications-functional-tests) repository.
 
-
-
 ## To run one off tasks
 
 Tasks are run through the `flask` command - run `flask --help` for more information. There are two sections we need to
@@ -120,26 +119,27 @@ care about: `flask db` contains alembic migration commands, and `flask command` 
 example, to purge all dynamically generated functional test data, do the following:
 
 Locally
+
 ```
 flask command purge_functional_test_data -u <functional tests user name prefix>
 ```
 
 On the server
+
 ```
 cf run-task notify-api "flask command purge_functional_test_data -u <functional tests user name prefix>"
 ```
 
 All commands and command options have a --help command if you need more information.
 
-
 ## To create a new worker app
 
 You need to:
 
-1. Create a new entry for your app in manifest-delivery-base.yml ([example](https://github.com/alphagov/notifications-api/commit/131495125e5dfb181010c8595b11b34ab412fc37#diff-a1885d77ffd0a5cb168590428871cd9e))
-1. Update the jenkins deployment job in the notifications-aws repo ([example](https://github.com/alphagov/notifications-aws/commit/69cf9912bd638bce088d4845e4b0a3b11a2cb74c#diff-17e034fe6186f2717b77ba277e0a5828))
-1. Add the new worker's log group to the list of logs groups we get alerts about and we ship them to kibana ([example](https://github.com/alphagov/notifications-aws/commit/69cf9912bd638bce088d4845e4b0a3b11a2cb74c#diff-501ffa3502adce988e810875af546b97))
-1. Optionally add it to the autoscaler ([example](https://github.com/alphagov/notifications-paas-autoscaler/commit/16d4cd0bdc851da2fab9fad1c9130eb94acf3d15))
+1.  Create a new entry for your app in manifest-delivery-base.yml ([example](https://github.com/alphagov/notifications-api/commit/131495125e5dfb181010c8595b11b34ab412fc37#diff-a1885d77ffd0a5cb168590428871cd9e))
+1.  Update the jenkins deployment job in the notifications-aws repo ([example](https://github.com/alphagov/notifications-aws/commit/69cf9912bd638bce088d4845e4b0a3b11a2cb74c#diff-17e034fe6186f2717b77ba277e0a5828))
+1.  Add the new worker's log group to the list of logs groups we get alerts about and we ship them to kibana ([example](https://github.com/alphagov/notifications-aws/commit/69cf9912bd638bce088d4845e4b0a3b11a2cb74c#diff-501ffa3502adce988e810875af546b97))
+1.  Optionally add it to the autoscaler ([example](https://github.com/alphagov/notifications-paas-autoscaler/commit/16d4cd0bdc851da2fab9fad1c9130eb94acf3d15))
 
 **Important:**
 
@@ -153,7 +153,7 @@ This means that the first deployment of your app must happen manually.
 
 To do this:
 
-1. Ensure your code is backwards compatible
-1. From the root of this repo run `CF_APP=<APP_NAME> make <cf-space> cf-push`
+1.  Ensure your code is backwards compatible
+1.  From the root of this repo run `CF_APP=<APP_NAME> make <cf-space> cf-push`
 
 Once this is done, you can push your deployment changes to jenkins to have your app deployed on every deployment.

--- a/api/app/clients/sms/identity.py
+++ b/api/app/clients/sms/identity.py
@@ -13,7 +13,7 @@ class IdentitySMSClient(SmsClient):
 
     @property
     def name(self):
-        return 'ses'
+        return 'identity'
 
     def get_name(self):
         return self.name

--- a/api/app/clients/sms/telstra.py
+++ b/api/app/clients/sms/telstra.py
@@ -1,0 +1,59 @@
+from monotonic import monotonic
+from app.clients.sms import SmsClient
+import Telstra_Messaging
+from Telstra_Messaging.rest import ApiException
+
+class TelstraSMSClient(SmsClient):
+    def __init__(self, client_id=None, client_secret=None, *args, **kwargs):
+        super(TelstraSMSClient, self).__init__(*args, **kwargs)
+        self._client_id = client_id
+        self._client_secret = client_secret
+
+    def init_app(self, app, *args, **kwargs):
+        self.current_app = app
+
+    @property
+    def name(self):
+        return 'telstra'
+
+    def get_name(self):
+        return self.name
+
+    def send_sms(self, to, content, reference, sender=None):
+        conf = self.auth()
+
+        api_instance = Telstra_Messaging.MessagingApi(Telstra_Messaging.ApiClient(conf))
+        payload = Telstra_Messaging.SendSMSRequest(to=to, body=content)
+
+        start_time = monotonic()
+        try:
+            resp = api_instance.send_sms(payload)
+            self.current_app.logger.info("Telstra send SMS request for {} succeeded: {}".format(reference, resp))
+        except Exception as e:
+            self.current_app.logger.error("Telstra send SMS request for {} failed".format(reference))
+            raise e
+        finally:
+            elapsed_time = monotonic() - start_time
+            self.current_app.logger.info("Telstra send SMS request for {} finished in {}".format(reference, elapsed_time))
+
+    def auth(self):
+        grant_type = 'client_credentials'
+
+        api_instance = Telstra_Messaging.AuthenticationApi()
+
+        start_time = monotonic()
+        try:
+            resp = api_instance.auth_token(self._client_id, self._client_secret, grant_type)
+
+            self.current_app.logger.info("Telstra auth request succeeded")
+
+            conf = Telstra_Messaging.Configuration()
+            conf.access_token = resp.access_token
+
+            return conf
+        except Exception as e:
+            self.current_app.logger.error("Telstra auth request failed")
+            raise e
+        finally:
+            elapsed_time = monotonic() - start_time
+            self.current_app.logger.info("Telstra auth request finished in {}".format(elapsed_time))

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -154,7 +154,7 @@ class Config(object):
     ORGANISATION_INVITATION_EMAIL_TEMPLATE_ID = '203566f0-d835-47c5-aa06-932439c86573'
 
     BROKER_URL = 'sqla+{database_url}'.format(database_url=SQLALCHEMY_DATABASE_URI)
-    
+
     """
     BROKER_URL = 'sqs://'
     BROKER_TRANSPORT_OPTIONS = {

--- a/api/app/dao/provider_details_dao.py
+++ b/api/app/dao/provider_details_dao.py
@@ -26,10 +26,10 @@ def get_provider_details_by_identifier(identifier):
 
 def get_alternative_sms_provider(identifier):
     alternate_provider = None
-    if identifier == 'firetext':
-        alternate_provider = 'mmg'
-    elif identifier == 'mmg':
-        alternate_provider = 'firetext'
+    if identifier == 'telstra':
+        alternate_provider = 'identity'
+    elif identifier == 'identity':
+        alternate_provider = 'telstra'
 
     return ProviderDetails.query.filter_by(identifier=alternate_provider).one()
 

--- a/api/manifest.yml
+++ b/api/manifest.yml
@@ -18,8 +18,10 @@ defaults: &defaults
     FLASK_APP: application.py
     SMTP_ADDR: smtp.hasmtp.cld.gov.au
     SMTP_USER: notifications@digital.gov.au
-    SMS_ADDR: https://sms-gateway.apps.y.cld.gov.au
-    SMS_USER: dto
+    TELSTRA_MESSAGING_CLIENT_ID: ''
+    TELSTRA_MESSAGING_CLIENT_SECRET: ''
+    IDENTITY_SMS_ADDR: https://sms-gateway.apps.y.cld.gov.au
+    IDENTITY_SMS_USER: dto
 
 applications:
 - name: notify-api


### PR DESCRIPTION
Keep the Identity client in place and fallback to it if the Telstra
client fails.

Note: the env vars changed in order to make it clear to which SMS client
they apply.

Note: the Telstra client doesn't account for provisioning the number -
i.e. it assumes that it has been provisioned separately.